### PR TITLE
fix: autoscale by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -111,17 +111,17 @@ variable "node_size" {
 variable "node_count" {
   description = "The number of worker nodes to use for the cluster"
   type        = number
-  default     = 2
+  default     = null
 }
 variable "min_node_count" {
   description = "The minimum number of worker nodes to use for the cluster if autoscaling is enabled"
   type        = number
-  default     = null
+  default     = 1
 }
 variable "max_node_count" {
   description = "The maximum number of worker nodes to use for the cluster if autoscaling is enabled"
   type        = number
-  default     = null
+  default     = 3
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This pr makes autoscaling default. It's within a small range so shouldn't incur a large cost for users, but you need 2 nodes to get jenkins-x running, but you need 3 to actually build and deploy an app. So we're enabling autoscaling to keep the cost the lowest possible for users while making sure they can get up and running nice and easily